### PR TITLE
perf: lazy-render episode lists and tighten Kingfisher caching

### DIFF
--- a/simalytics/Components/CustomKFImage.swift
+++ b/simalytics/Components/CustomKFImage.swift
@@ -23,9 +23,8 @@ struct CustomKFImage: View {
             ProgressView()
           }
           .resizable()
-          .serialize(as: .JPEG)
+          .setProcessor(DownsamplingImageProcessor(size: CGSize(width: width, height: height)))
           .cacheMemoryOnly(memoryCacheOnly)
-          .fromMemoryCacheOrRefresh(true)
           .memoryCacheExpiration(.days(7))
           .diskCacheExpiration(.days(30))
           .cancelOnDisappear(true)

--- a/simalytics/SimalyticsApp.swift
+++ b/simalytics/SimalyticsApp.swift
@@ -6,6 +6,7 @@
 //
 // swift-format lint ./Documents/GitHub/simalytics-ios/ -r
 
+import Kingfisher
 import Sentry
 import SimpleKeychain
 import SwiftData
@@ -61,6 +62,8 @@ struct SimalyticsApp: App {
   }()
 
   init() {
+    ImageCache.default.diskStorage.config.sizeLimit = 500 * 1024 * 1024
+
     SentrySDK.start { options in
       if let configuredDSN = (Bundle.main.infoDictionary?["SENTRY_DSN"] as? String)?
         .trimmingCharacters(in: .whitespacesAndNewlines),

--- a/simalytics/Views/Explore/AnimeDetailView.swift
+++ b/simalytics/Views/Explore/AnimeDetailView.swift
@@ -201,7 +201,7 @@ struct AnimeDetailView: View {
 
         if animeDetails?.anime_type == "tv" {
           if !filteredEpisodes.isEmpty {
-            VStack(alignment: .leading) {
+            LazyVStack(alignment: .leading) {
               HStack {
                 Menu {
                   ForEach(seasons, id: \.self) { season in

--- a/simalytics/Views/Explore/ShowDetailView.swift
+++ b/simalytics/Views/Explore/ShowDetailView.swift
@@ -200,7 +200,7 @@ struct ShowDetailView: View {
         Spacer()
 
         if !filteredEpisodes.isEmpty {
-          VStack(alignment: .leading) {
+          LazyVStack(alignment: .leading) {
             HStack {
               Menu {
                 ForEach(seasons, id: \.self) { season in


### PR DESCRIPTION
## Summary

- Addresses Sentry **SIMALYTICS-IOS-3** (N+1 image burst on `__backButtonAction`) by switching the episodes list in `ShowDetailView` / `AnimeDetailView` from `VStack` to `LazyVStack` — off-screen episode thumbnails no longer fetch up front.
- Cleans up `CustomKFImage` so Kingfisher's caches actually work as intended: removes `.fromMemoryCacheOrRefresh(true)` (was skipping the disk cache on every memory miss) and `.serialize(as: .JPEG)` (was stripping alpha from PNG sources like TMDB streaming-service logos). Adds a `DownsamplingImageProcessor` sized to the view frame to lower decoded-image memory.
- Caps `ImageCache.default.diskStorage` at 500 MB in `SimalyticsApp.init()` so the disk cache LRU-evicts instead of growing unbounded.

## Test plan

- [ ] Open a TV show with a long season; scroll through episodes — thumbnails should fade in lazily as rows enter view, not all at once.
- [ ] Same check on an anime detail view.
- [ ] Open `JustWatchView`, force-quit, reopen — streaming-service logos should keep PNG transparency on cache hit (previously re-encoded to JPEG on disk).
- [ ] Repeat navigation into the same detail view feels snappier on subsequent visits (disk cache now actually used for `memoryCacheOnly: false` callers).
- [ ] No visible regressions on poster lists (`TVListView`, `MovieListView`, `AnimeListView`) or detail screen posters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)