### PR TITLE
fix: harden sync and interaction stability

### DIFF
--- a/.changeset/calm-stable-posters.md
+++ b/.changeset/calm-stable-posters.md
@@ -1,0 +1,5 @@
+---
+"@kyter/simalytics-ios": patch
+---
+
+Improved watch-history sync resilience, prevented duplicate episode updates, and reduced stalls while browsing image-heavy and preview-rich screens.

--- a/simalytics.xcodeproj/project.pbxproj
+++ b/simalytics.xcodeproj/project.pbxproj
@@ -12,14 +12,30 @@
 		7CB91517D96B46F0B1618000 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 910C0B921C474ACE9F4A7C1B /* Sentry */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		3427C2FC2D6D20C70064B137 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3427C2E22D6D20C60064B137 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3427C2E92D6D20C60064B137;
+			remoteInfo = simalytics;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		3427C2EA2D6D20C60064B137 /* Simalytics.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simalytics.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3427C2FB2D6D20C70064B137 /* simalyticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = simalyticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		3427C2EC2D6D20C60064B137 /* simalytics */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = simalytics;
+			sourceTree = "<group>";
+		};
+		3427C2FE2D6D20C70064B137 /* simalyticsTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = simalyticsTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -35,6 +51,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3427C2F82D6D20C70064B137 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -42,6 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				3427C2EC2D6D20C60064B137 /* simalytics */,
+				3427C2FE2D6D20C70064B137 /* simalyticsTests */,
 				3427C2EB2D6D20C60064B137 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -50,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				3427C2EA2D6D20C60064B137 /* Simalytics.app */,
+				3427C2FB2D6D20C70064B137 /* simalyticsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -83,6 +108,29 @@
 			productReference = 3427C2EA2D6D20C60064B137 /* Simalytics.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3427C2FA2D6D20C70064B137 /* simalyticsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3427C3122D6D20C70064B137 /* Build configuration list for PBXNativeTarget "simalyticsTests" */;
+			buildPhases = (
+				3427C2F72D6D20C70064B137 /* Sources */,
+				3427C2F82D6D20C70064B137 /* Frameworks */,
+				3427C2F92D6D20C70064B137 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3427C2FD2D6D20C70064B137 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3427C2FE2D6D20C70064B137 /* simalyticsTests */,
+			);
+			name = simalyticsTests;
+			packageProductDependencies = (
+			);
+			productName = simalyticsTests;
+			productReference = 3427C2FB2D6D20C70064B137 /* simalyticsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -95,6 +143,10 @@
 				TargetAttributes = {
 					3427C2E92D6D20C60064B137 = {
 						CreatedOnToolsVersion = 16.2;
+					};
+					3427C2FA2D6D20C70064B137 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 3427C2E92D6D20C60064B137;
 					};
 				};
 			};
@@ -118,12 +170,20 @@
 			projectRoot = "";
 			targets = (
 				3427C2E92D6D20C60064B137 /* simalytics */,
+				3427C2FA2D6D20C70064B137 /* simalyticsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3427C2E82D6D20C60064B137 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3427C2F92D6D20C70064B137 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -192,7 +252,22 @@ fi
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3427C2F72D6D20C70064B137 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3427C2FD2D6D20C70064B137 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3427C2E92D6D20C60064B137 /* simalytics */;
+			targetProxy = 3427C2FC2D6D20C70064B137 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3427C30D2D6D20C70064B137 /* Debug */ = {
@@ -423,6 +498,52 @@ fi
 			};
 			name = Release;
 		};
+		3427C3132D6D20C70064B137 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 131;
+				DEVELOPMENT_TEAM = W2W286Y75F;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0.15;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kyter.simalyticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Simalytics.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Simalytics";
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		3427C3142D6D20C70064B137 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 131;
+				DEVELOPMENT_TEAM = W2W286Y75F;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0.15;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kyter.simalyticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Simalytics.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Simalytics";
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -440,6 +561,15 @@ fi
 			buildConfigurations = (
 				3427C3102D6D20C70064B137 /* Debug */,
 				3427C3112D6D20C70064B137 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3427C3122D6D20C70064B137 /* Build configuration list for PBXNativeTarget "simalyticsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3427C3132D6D20C70064B137 /* Debug */,
+				3427C3142D6D20C70064B137 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/simalytics.xcodeproj/xcshareddata/xcschemes/simalytics.xcscheme
+++ b/simalytics.xcodeproj/xcshareddata/xcschemes/simalytics.xcscheme
@@ -41,17 +41,6 @@
                ReferencedContainer = "container:simalytics.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3427C3042D6D20C70064B137"
-               BuildableName = "simalyticsUITests.xctest"
-               BlueprintName = "simalyticsUITests"
-               ReferencedContainer = "container:simalytics.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/simalytics/Components/CustomKFImage.swift
+++ b/simalytics/Components/CustomKFImage.swift
@@ -39,11 +39,17 @@ struct CustomKFImage: View {
 
   var body: some View {
     Group {
-      if let imageUrlString = imageUrlString, !imageUrlString.isEmpty, let url = URL(string: imageUrlString) {
-        let processorSize = CGSize(width: max(width * displayScale, 1), height: max(height * displayScale, 1))
+      if let imageUrlString = imageUrlString, !imageUrlString.isEmpty,
+        let url = URL(string: imageUrlString)
+      {
+        let processorSize = CGSize(
+          width: max(width * displayScale, 1), height: max(height * displayScale, 1))
         KFImage(url)
           .requestModifier(Self.bypassURLCache)
-          .fade(duration: 0.33)
+          // Do not add a per-cell fade here. Collection screens can complete
+          // many poster requests together, and Kingfisher implements fade by
+          // publishing each completion inside `withAnimation` on the main
+          // actor. The resulting SwiftUI graph-update burst caused IOS-10.
           .placeholder {
             ProgressView()
           }

--- a/simalytics/Components/Recommendations.swift
+++ b/simalytics/Components/Recommendations.swift
@@ -12,68 +12,96 @@ struct Recommendations: View {
   var recommendations: [RecommendationModel]?
   @AppStorage("hideAnime") private var hideAnime = false
   @Environment(\.modelContext) private var context
+  @State private var localSnapshots = LocalMediaSnapshots()
+
+  private var visibleRecommendations: [RecommendationModel] {
+    (recommendations ?? []).filter { !hideAnime || $0.type != "anime" }
+  }
+
+  private var localSnapshotRequest: LocalMediaSnapshots.Request {
+    LocalMediaSnapshots.Request(
+      movieIDs: visibleRecommendations.filter { $0.type == "movie" }.map { $0.ids.simkl },
+      showIDs: visibleRecommendations.filter { $0.type == "tv" }.map { $0.ids.simkl },
+      animeIDs: visibleRecommendations.filter { $0.type == "anime" }.map { $0.ids.simkl }
+    )
+  }
+
+  private func refreshLocalSnapshots() {
+    localSnapshots = LocalMediaSnapshots.fetch(localSnapshotRequest, context: context)
+  }
 
   var body: some View {
-    if let recommendations = recommendations?.filter({ !hideAnime || $0.type != "anime" }), !recommendations.isEmpty {
-      VStack(alignment: .leading) {
-        Group {
-          ExploreGroupTitle(title: "Users Also Watched")
+    Group {
+      if !visibleRecommendations.isEmpty {
+        VStack(alignment: .leading) {
+          Group {
+            ExploreGroupTitle(title: "Users Also Watched")
 
-          ScrollView(.horizontal) {
-            HStack(spacing: 16) {
-              ForEach(
-                recommendations, id: \.ids.simkl
-              ) { item in
-                NavigationLink(
-                  destination: {
-                    let type = item.type
-                    let id = item.ids.simkl
-                    if type == "tv" {
-                      ShowDetailView(simkl_id: id)
-                    } else if type == "movie" {
-                      MovieDetailView(simkl_id: id)
-                    } else if type == "anime" {
-                      AnimeDetailView(simkl_id: id)
+            ScrollView(.horizontal) {
+              HStack(spacing: 16) {
+                ForEach(
+                  visibleRecommendations, id: \.ids.simkl
+                ) { item in
+                  NavigationLink(
+                    destination: {
+                      let type = item.type
+                      let id = item.ids.simkl
+                      if type == "tv" {
+                        ShowDetailView(simkl_id: id)
+                      } else if type == "movie" {
+                        MovieDetailView(simkl_id: id)
+                      } else if type == "anime" {
+                        AnimeDetailView(simkl_id: id)
+                      }
+                    }
+                  ) {
+                    VStack {
+                      CustomKFImage(
+                        imageUrlString: item.poster != nil
+                          ? "\(SIMKL_CDN_URL)/posters/\(item.poster!)_m.jpg"
+                          : nil,
+                        memoryCacheOnly: true,
+                        height: 147,
+                        width: 100
+                      )
+                      ExploreTitle(title: item.title)
                     }
                   }
-                ) {
-                  VStack {
-                    CustomKFImage(
-                      imageUrlString: item.poster != nil
-                        ? "\(SIMKL_CDN_URL)/posters/\(item.poster!)_m.jpg"
-                        : nil,
-                      memoryCacheOnly: true,
-                      height: 147,
-                      width: 100
+                  .buttonStyle(.plain)
+                  .contextMenu {
+                    ShareLink(
+                      item: URL(
+                        string:
+                          "https://simkl.com/\(item.type == "tv" ? "tv" : item.type)/\(item.ids.simkl)"
+                      )!,
+                      subject: Text(item.title),
+                      message: Text("Check out \(item.title)!")
+                    ) {
+                      Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                  } preview: {
+                    SmartPreviewCard(
+                      simklId: item.ids.simkl,
+                      title: item.title,
+                      year: item.year,
+                      poster: item.poster,
+                      mediaType: item.type,
+                      localData: localSnapshots.data(simklID: item.ids.simkl, mediaType: item.type)
                     )
-                    ExploreTitle(title: item.title)
                   }
-                }
-                .buttonStyle(.plain)
-                .contextMenu {
-                  ShareLink(
-                    item: URL(string: "https://simkl.com/\(item.type == "tv" ? "tv" : item.type)/\(item.ids.simkl)")!,
-                    subject: Text(item.title),
-                    message: Text("Check out \(item.title)!")
-                  ) {
-                    Label("Share", systemImage: "square.and.arrow.up")
-                  }
-                } preview: {
-                  SmartPreviewCard(
-                    simklId: item.ids.simkl,
-                    title: item.title,
-                    year: item.year,
-                    poster: item.poster,
-                    mediaType: item.type,
-                    localData: LocalDataLookup.lookup(simklId: item.ids.simkl, mediaType: item.type, context: context)
-                  )
                 }
               }
+              .padding([.leading, .trailing, .bottom])
             }
-            .padding([.leading, .trailing, .bottom])
           }
         }
       }
+    }
+    .task(id: localSnapshotRequest) {
+      refreshLocalSnapshots()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .localMediaSnapshotsDidChange)) { _ in
+      refreshLocalSnapshots()
     }
   }
 }

--- a/simalytics/Components/SmartPreviewCard.swift
+++ b/simalytics/Components/SmartPreviewCard.swift
@@ -5,79 +5,9 @@
 //  Created by Nick Reisenauer on 1/8/26.
 //
 
-import SwiftData
 import SwiftUI
 
-/// Helper struct to hold looked-up local data
-struct LocalMediaData {
-  let year: Int?
-  let userRating: Int?
-  let status: String?
-  let animeType: String?
-  let watchedEpisodes: Int?
-  let totalEpisodes: Int?
-}
-
-/// Helper to look up local data for a media item
-/// Call this from a view that has access to modelContext
-enum LocalDataLookup {
-  static func lookup(
-    simklId: Int,
-    mediaType: String,
-    context: ModelContext
-  ) -> LocalMediaData? {
-    switch mediaType {
-    case "movie":
-      let descriptor = FetchDescriptor<V1.SDMovies>(
-        predicate: #Predicate { $0.simkl == simklId }
-      )
-      if let movie = try? context.fetch(descriptor).first {
-        return LocalMediaData(
-          year: movie.year,
-          userRating: movie.user_rating,
-          status: movie.status,
-          animeType: nil,
-          watchedEpisodes: nil,
-          totalEpisodes: nil
-        )
-      }
-    case "tv":
-      let descriptor = FetchDescriptor<V1.SDShows>(
-        predicate: #Predicate { $0.simkl == simklId }
-      )
-      if let show = try? context.fetch(descriptor).first {
-        return LocalMediaData(
-          year: show.year,
-          userRating: show.user_rating,
-          status: show.status,
-          animeType: nil,
-          watchedEpisodes: show.watched_episodes_count,
-          totalEpisodes: show.total_episodes_count
-        )
-      }
-    case "anime":
-      let descriptor = FetchDescriptor<V1.SDAnimes>(
-        predicate: #Predicate { $0.simkl == simklId }
-      )
-      if let anime = try? context.fetch(descriptor).first {
-        return LocalMediaData(
-          year: anime.year,
-          userRating: anime.user_rating,
-          status: anime.status,
-          animeType: anime.anime_type,
-          watchedEpisodes: anime.watched_episodes_count,
-          totalEpisodes: anime.total_episodes_count
-        )
-      }
-    default:
-      break
-    }
-    return nil
-  }
-}
-
-/// A preview card that uses pre-looked-up local data
-/// The parent view should call LocalDataLookup.lookup() and pass the result here
+/// A preview card that uses value-only data preloaded by its parent.
 struct SmartPreviewCard: View {
   let simklId: Int
   let title: String

--- a/simalytics/Models/API/Watchlist/AnimeWatchlistModel.swift
+++ b/simalytics/Models/API/Watchlist/AnimeWatchlistModel.swift
@@ -7,11 +7,33 @@
 
 import Foundation
 
-struct AnimeWatchlistModel: Codable, Sendable {
+struct AnimeWatchlistModel: Sendable {
   let list: String?
   let last_watched_at: String?
   let simkl: Int
   let episodes_watched: Int?
   let episodes_aired: Int?
   var seasons: [WatchlistSeason]?
+}
+
+extension AnimeWatchlistModel: Decodable {
+  private enum CodingKeys: String, CodingKey {
+    case list, last_watched_at, simkl, ids, episodes_watched, episodes_aired, seasons
+  }
+
+  private struct IDs: Decodable {
+    let simkl: Int
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    list = try container.decodeIfPresent(String.self, forKey: .list)
+    last_watched_at = try container.decodeIfPresent(String.self, forKey: .last_watched_at)
+    simkl =
+      try container.decodeIfPresent(Int.self, forKey: .simkl)
+      ?? container.decode(IDs.self, forKey: .ids).simkl
+    episodes_watched = try container.decodeIfPresent(Int.self, forKey: .episodes_watched)
+    episodes_aired = try container.decodeIfPresent(Int.self, forKey: .episodes_aired)
+    seasons = try container.decodeIfPresent([WatchlistSeason].self, forKey: .seasons)
+  }
 }

--- a/simalytics/Models/API/Watchlist/ShowWatchlistModel.swift
+++ b/simalytics/Models/API/Watchlist/ShowWatchlistModel.swift
@@ -7,11 +7,33 @@
 
 import Foundation
 
-struct ShowWatchlistModel: Codable, Sendable {
+struct ShowWatchlistModel: Sendable {
   let list: String?
   let last_watched_at: String?
   let simkl: Int
   let episodes_watched: Int?
   let episodes_aired: Int?
   var seasons: [WatchlistSeason]?
+}
+
+extension ShowWatchlistModel: Decodable {
+  private enum CodingKeys: String, CodingKey {
+    case list, last_watched_at, simkl, ids, episodes_watched, episodes_aired, seasons
+  }
+
+  private struct IDs: Decodable {
+    let simkl: Int
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    list = try container.decodeIfPresent(String.self, forKey: .list)
+    last_watched_at = try container.decodeIfPresent(String.self, forKey: .last_watched_at)
+    simkl =
+      try container.decodeIfPresent(Int.self, forKey: .simkl)
+      ?? container.decode(IDs.self, forKey: .ids).simkl
+    episodes_watched = try container.decodeIfPresent(Int.self, forKey: .episodes_watched)
+    episodes_aired = try container.decodeIfPresent(Int.self, forKey: .episodes_aired)
+    seasons = try container.decodeIfPresent([WatchlistSeason].self, forKey: .seasons)
+  }
 }

--- a/simalytics/Models/LocalMediaData.swift
+++ b/simalytics/Models/LocalMediaData.swift
@@ -1,0 +1,16 @@
+//
+//  LocalMediaData.swift
+//  simalytics
+//
+
+import Foundation
+
+/// Value-only media state used by context-menu previews.
+struct LocalMediaData: Equatable, Sendable {
+  let year: Int?
+  let userRating: Int?
+  let status: String?
+  let animeType: String?
+  let watchedEpisodes: Int?
+  let totalEpisodes: Int?
+}

--- a/simalytics/ViewModels/AnimeDetailViewModel.swift
+++ b/simalytics/ViewModels/AnimeDetailViewModel.swift
@@ -23,7 +23,9 @@ extension AnimeDetailView {
       let (data, response) = try await URLSession.shared.simklData(for: request)
       guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
 
-      if String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) == "[]" {
+      if String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        == "[]"
+      {
         return nil
       }
 
@@ -35,7 +37,21 @@ extension AnimeDetailView {
   }
 
   @discardableResult
-  static func markEpisodeUnwatched(_ accessToken: String, _ title: String, _ simklId: Int, _ season: Int, _ episode: Int) async -> String? {
+  static func markEpisodeUnwatched(
+    _ accessToken: String,
+    _ title: String,
+    _ simklId: Int,
+    _ season: Int,
+    _ episode: Int
+  ) async -> SimklMutationResult {
+    guard simklId > 0,
+      let selection = validatedSimklEpisode(season: season, episode: episode)
+    else {
+      let error = SimklMutationError.invalidEpisode
+      reportError(error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
+    }
+
     do {
       let url = URL(string: "https://api.simkl.com/sync/history/remove")!
       var request = URLRequest(url: url)
@@ -53,10 +69,10 @@ extension AnimeDetailView {
             ],
             "seasons": [
               [
-                "number": season,
+                "number": selection.season,
                 "episodes": [
                   [
-                    "number": episode
+                    "number": selection.episode
                   ]
                 ],
               ]
@@ -66,24 +82,29 @@ extension AnimeDetailView {
       ]
       request.httpBody = try JSONSerialization.data(withJSONObject: body)
       try await performSimklMutationRequest(request)
-      return nil
+      return .succeeded
     } catch {
-      if isSimklCancellationError(error) { return nil }
+      if isSimklCancellationError(error) { return .cancelled }
       reportError(error)
-      return simklMutationUserMessage(for: error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
     }
   }
 
   // Batched variant for callers (e.g. up-next sync) that need watched data
   // for many anime at once. Thin wrapper around the shared helper so the
   // call site stays clean and TV/anime behaviour can't drift apart.
-  static func getAnimeWatchlistBatch(_ simklIDs: [Int], _ accessToken: String) async -> SimklWatchedBatch<AnimeWatchlistModel> {
+  static func getAnimeWatchlistBatch(_ simklIDs: [Int], _ accessToken: String) async
+    -> SimklWatchedBatch<AnimeWatchlistModel>
+  {
     await simklWatchedBatch(simklIDs: simklIDs, type: "anime", accessToken: accessToken)
   }
 
-  static func getAnimeWatchlist(_ simkl_id: Int, _ accessToken: String) async -> AnimeWatchlistModel? {
+  static func getAnimeWatchlist(_ simkl_id: Int, _ accessToken: String) async
+    -> AnimeWatchlistModel?
+  {
     do {
-      let urlComponents = URLComponents(string: "https://api.simkl.com/sync/watched?extended=episodes,specials")!
+      let urlComponents = URLComponents(
+        string: "https://api.simkl.com/sync/watched?extended=episodes,specials")!
 
       var request = URLRequest(url: urlComponents.url!)
       request.httpMethod = "POST"
@@ -96,7 +117,16 @@ extension AnimeDetailView {
       let (data, response) = try await URLSession.shared.simklData(for: request)
       guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
 
-      return try JSONDecoder().decode([AnimeWatchlistModel].self, from: data).first
+      let decoded = try decodeSimklWatchedResponse(AnimeWatchlistModel.self, from: data)
+      if decoded.malformedItemCount > 0 {
+        reportSimklWatchedSchemaIssue(
+          type: "anime",
+          malformedItemCount: decoded.malformedItemCount,
+          responseItemCount: decoded.items.count + decoded.terminalRejectionCount
+            + decoded.malformedItemCount
+        )
+      }
+      return decoded.items.first
     } catch {
       reportError(error)
       return nil
@@ -129,7 +159,21 @@ extension AnimeDetailView {
   }
 
   @discardableResult
-  static func markEpisodeWatched(_ accessToken: String, _ title: String, _ simklId: Int, _ season: Int, _ episode: Int) async -> String? {
+  static func markEpisodeWatched(
+    _ accessToken: String,
+    _ title: String,
+    _ simklId: Int,
+    _ season: Int,
+    _ episode: Int
+  ) async -> SimklMutationResult {
+    guard simklId > 0,
+      let selection = validatedSimklEpisode(season: season, episode: episode)
+    else {
+      let error = SimklMutationError.invalidEpisode
+      reportError(error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
+    }
+
     do {
       let url = URL(string: "https://api.simkl.com/sync/history")!
       var request = URLRequest(url: url)
@@ -149,10 +193,10 @@ extension AnimeDetailView {
             ],
             "seasons": [
               [
-                "number": season,
+                "number": selection.season,
                 "episodes": [
                   [
-                    "number": episode,
+                    "number": selection.episode,
                     "watched_at": dateString,
                   ]
                 ],
@@ -163,15 +207,17 @@ extension AnimeDetailView {
       ]
       request.httpBody = try JSONSerialization.data(withJSONObject: body)
       try await performSimklMutationRequest(request)
-      return nil
+      return .succeeded
     } catch {
-      if isSimklCancellationError(error) { return nil }
+      if isSimklCancellationError(error) { return .cancelled }
       reportError(error)
-      return simklMutationUserMessage(for: error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
     }
   }
 
-  static func getAnimeEpisodes(_ simkl_id: Int, countSeasons: Bool = false) async -> [AnimeEpisodeModel] {
+  static func getAnimeEpisodes(_ simkl_id: Int, countSeasons: Bool = false) async
+    -> [AnimeEpisodeModel]
+  {
     do {
       var urlComponents = URLComponents(string: "https://api.simkl.com/anime/episodes/\(simkl_id)")!
       urlComponents.queryItems = [
@@ -220,7 +266,9 @@ extension AnimeDetailView {
 }
 
 extension AnimeWatchlistButton {
-  static func updateAnimeList(_ simkl_id: Int, _ accessToken: String, _ list: String) async -> String? {
+  static func updateAnimeList(_ simkl_id: Int, _ accessToken: String, _ list: String) async
+    -> String?
+  {
     do {
       if list == "nil" {
         let urlComponents = URLComponents(string: "https://api.simkl.com/sync/history/remove")!

--- a/simalytics/ViewModels/EpisodeMutationCoordinator.swift
+++ b/simalytics/ViewModels/EpisodeMutationCoordinator.swift
@@ -1,0 +1,56 @@
+//
+//  EpisodeMutationCoordinator.swift
+//  simalytics
+//
+
+import Observation
+
+@Observable @MainActor
+final class EpisodeMutationCoordinator {
+  enum RunResult: Equatable {
+    case succeeded
+    case failed(userMessage: String)
+    case cancelled
+    case suppressed
+  }
+
+  private(set) var isUpdating = false
+
+  func run(
+    optimisticUpdate: () -> Void,
+    rollback: () -> Void,
+    mutation: () async -> SimklMutationResult,
+    commit: () -> Void,
+    reconcile: () async -> Void
+  ) async -> RunResult {
+    guard !isUpdating else { return .suppressed }
+    isUpdating = true
+    defer { isUpdating = false }
+
+    optimisticUpdate()
+    let mutationResult = await mutation()
+
+    switch mutationResult {
+    case .cancelled:
+      rollback()
+      return .cancelled
+
+    case .failed(let userMessage):
+      rollback()
+      guard !Task.isCancelled else { return .cancelled }
+      await reconcile()
+      guard !Task.isCancelled else { return .cancelled }
+      return .failed(userMessage: userMessage)
+
+    case .succeeded:
+      // A server-acknowledged mutation must not be rolled back merely because
+      // the sheet disappeared after the response arrived. The invalidated
+      // cache will reconcile it on the next active sync.
+      guard !Task.isCancelled else { return .cancelled }
+      commit()
+      await reconcile()
+      guard !Task.isCancelled else { return .cancelled }
+      return .succeeded
+    }
+  }
+}

--- a/simalytics/ViewModels/LocalMediaSnapshots.swift
+++ b/simalytics/ViewModels/LocalMediaSnapshots.swift
@@ -1,0 +1,133 @@
+//
+//  LocalMediaSnapshots.swift
+//  simalytics
+//
+
+import Foundation
+import SwiftData
+
+/// In-memory, value-only index for context-menu preview data.
+struct LocalMediaSnapshots: Sendable {
+  struct Request: Hashable, Sendable {
+    let movieIDs: [Int]
+    let showIDs: [Int]
+    let animeIDs: [Int]
+
+    init(movieIDs: [Int] = [], showIDs: [Int] = [], animeIDs: [Int] = []) {
+      self.movieIDs = Array(Set(movieIDs)).sorted()
+      self.showIDs = Array(Set(showIDs)).sorted()
+      self.animeIDs = Array(Set(animeIDs)).sorted()
+    }
+  }
+
+  private var movies: [Int: LocalMediaData] = [:]
+  private var shows: [Int: LocalMediaData] = [:]
+  private var animes: [Int: LocalMediaData] = [:]
+
+  func data(simklID: Int, mediaType: String) -> LocalMediaData? {
+    switch mediaType {
+    case "movie", "movies": movies[simklID]
+    case "tv", "show": shows[simklID]
+    case "anime": animes[simklID]
+    default: nil
+    }
+  }
+
+  /// Fetches each requested model type at most once, then immediately copies
+  /// model values into dictionaries. The context and `@Model` instances stay
+  /// on the main actor and never enter SwiftUI rendering state.
+  @MainActor
+  static func fetch(_ request: Request, context: ModelContext) -> LocalMediaSnapshots {
+    var snapshots = LocalMediaSnapshots()
+
+    if !request.movieIDs.isEmpty {
+      let movieIDs = request.movieIDs
+      do {
+        let models = try context.fetch(
+          FetchDescriptor<V1.SDMovies>(
+            predicate: #Predicate { movieIDs.contains($0.simkl) }
+          ))
+        snapshots.movies = Dictionary(
+          models.map {
+            (
+              $0.simkl,
+              LocalMediaData(
+                year: $0.year,
+                userRating: $0.user_rating,
+                status: $0.status,
+                animeType: nil,
+                watchedEpisodes: nil,
+                totalEpisodes: nil
+              )
+            )
+          },
+          uniquingKeysWith: { _, latest in latest }
+        )
+      } catch {
+        reportError(error)
+      }
+    }
+
+    if !request.showIDs.isEmpty {
+      let showIDs = request.showIDs
+      do {
+        let models = try context.fetch(
+          FetchDescriptor<V1.SDShows>(
+            predicate: #Predicate { showIDs.contains($0.simkl) }
+          ))
+        snapshots.shows = Dictionary(
+          models.map {
+            (
+              $0.simkl,
+              LocalMediaData(
+                year: $0.year,
+                userRating: $0.user_rating,
+                status: $0.status,
+                animeType: nil,
+                watchedEpisodes: $0.watched_episodes_count,
+                totalEpisodes: $0.total_episodes_count
+              )
+            )
+          },
+          uniquingKeysWith: { _, latest in latest }
+        )
+      } catch {
+        reportError(error)
+      }
+    }
+
+    if !request.animeIDs.isEmpty {
+      let animeIDs = request.animeIDs
+      do {
+        let models = try context.fetch(
+          FetchDescriptor<V1.SDAnimes>(
+            predicate: #Predicate { animeIDs.contains($0.simkl) }
+          ))
+        snapshots.animes = Dictionary(
+          models.map {
+            (
+              $0.simkl,
+              LocalMediaData(
+                year: $0.year,
+                userRating: $0.user_rating,
+                status: $0.status,
+                animeType: $0.anime_type,
+                watchedEpisodes: $0.watched_episodes_count,
+                totalEpisodes: $0.total_episodes_count
+              )
+            )
+          },
+          uniquingKeysWith: { _, latest in latest }
+        )
+      } catch {
+        reportError(error)
+      }
+    }
+
+    return snapshots
+  }
+}
+
+extension Notification.Name {
+  static let localMediaSnapshotsDidChange = Notification.Name("LocalMediaSnapshotsDidChange")
+}

--- a/simalytics/ViewModels/ShowDetailViewModel.swift
+++ b/simalytics/ViewModels/ShowDetailViewModel.swift
@@ -23,7 +23,9 @@ extension ShowDetailView {
       let (data, response) = try await URLSession.shared.simklData(for: request)
       guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
 
-      if String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) == "[]" {
+      if String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        == "[]"
+      {
         return nil
       }
 
@@ -37,13 +39,17 @@ extension ShowDetailView {
   // Batched variant for callers (e.g. up-next sync) that need watched data
   // for many shows at once. Thin wrapper around the shared helper so the
   // call site stays clean and TV/anime behaviour can't drift apart.
-  static func getShowWatchlistBatch(_ simklIDs: [Int], _ accessToken: String) async -> SimklWatchedBatch<ShowWatchlistModel> {
+  static func getShowWatchlistBatch(_ simklIDs: [Int], _ accessToken: String) async
+    -> SimklWatchedBatch<ShowWatchlistModel>
+  {
     await simklWatchedBatch(simklIDs: simklIDs, type: "show", accessToken: accessToken)
   }
 
-  static func getShowWatchlist(_ simkl_id: Int, _ accessToken: String) async -> ShowWatchlistModel? {
+  static func getShowWatchlist(_ simkl_id: Int, _ accessToken: String) async -> ShowWatchlistModel?
+  {
     do {
-      let urlComponents = URLComponents(string: "https://api.simkl.com/sync/watched?extended=episodes,specials")!
+      let urlComponents = URLComponents(
+        string: "https://api.simkl.com/sync/watched?extended=episodes,specials")!
       var request = URLRequest(url: urlComponents.url!)
       request.httpMethod = "POST"
       request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -55,7 +61,16 @@ extension ShowDetailView {
       let (data, response) = try await URLSession.shared.simklData(for: request)
       guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
 
-      return try JSONDecoder().decode([ShowWatchlistModel].self, from: data).first
+      let decoded = try decodeSimklWatchedResponse(ShowWatchlistModel.self, from: data)
+      if decoded.malformedItemCount > 0 {
+        reportSimklWatchedSchemaIssue(
+          type: "show",
+          malformedItemCount: decoded.malformedItemCount,
+          responseItemCount: decoded.items.count + decoded.terminalRejectionCount
+            + decoded.malformedItemCount
+        )
+      }
+      return decoded.items.first
     } catch {
       reportError(error)
       return nil
@@ -63,7 +78,21 @@ extension ShowDetailView {
   }
 
   @discardableResult
-  static func markEpisodeUnwatched(_ accessToken: String, _ title: String, _ simklId: Int, _ season: Int, _ episode: Int) async -> String? {
+  static func markEpisodeUnwatched(
+    _ accessToken: String,
+    _ title: String,
+    _ simklId: Int,
+    _ season: Int,
+    _ episode: Int
+  ) async -> SimklMutationResult {
+    guard simklId > 0,
+      let selection = validatedSimklEpisode(season: season, episode: episode)
+    else {
+      let error = SimklMutationError.invalidEpisode
+      reportError(error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
+    }
+
     do {
       let url = URL(string: "https://api.simkl.com/sync/history/remove")!
       var request = URLRequest(url: url)
@@ -81,10 +110,10 @@ extension ShowDetailView {
             ],
             "seasons": [
               [
-                "number": season,
+                "number": selection.season,
                 "episodes": [
                   [
-                    "number": episode
+                    "number": selection.episode
                   ]
                 ],
               ]
@@ -94,16 +123,30 @@ extension ShowDetailView {
       ]
       request.httpBody = try JSONSerialization.data(withJSONObject: body)
       try await performSimklMutationRequest(request)
-      return nil
+      return .succeeded
     } catch {
-      if isSimklCancellationError(error) { return nil }
+      if isSimklCancellationError(error) { return .cancelled }
       reportError(error)
-      return simklMutationUserMessage(for: error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
     }
   }
 
   @discardableResult
-  static func markEpisodeWatched(_ accessToken: String, _ title: String, _ simklId: Int, _ season: Int, _ episode: Int) async -> String? {
+  static func markEpisodeWatched(
+    _ accessToken: String,
+    _ title: String,
+    _ simklId: Int,
+    _ season: Int,
+    _ episode: Int
+  ) async -> SimklMutationResult {
+    guard simklId > 0,
+      let selection = validatedSimklEpisode(season: season, episode: episode)
+    else {
+      let error = SimklMutationError.invalidEpisode
+      reportError(error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
+    }
+
     do {
       let url = URL(string: "https://api.simkl.com/sync/history")!
       var request = URLRequest(url: url)
@@ -123,10 +166,10 @@ extension ShowDetailView {
             ],
             "seasons": [
               [
-                "number": season,
+                "number": selection.season,
                 "episodes": [
                   [
-                    "number": episode,
+                    "number": selection.episode,
                     "watched_at": dateString,
                   ]
                 ],
@@ -137,11 +180,11 @@ extension ShowDetailView {
       ]
       request.httpBody = try JSONSerialization.data(withJSONObject: body)
       try await performSimklMutationRequest(request)
-      return nil
+      return .succeeded
     } catch {
-      if isSimklCancellationError(error) { return nil }
+      if isSimklCancellationError(error) { return .cancelled }
       reportError(error)
-      return simklMutationUserMessage(for: error)
+      return .failed(userMessage: simklMutationUserMessage(for: error))
     }
   }
 
@@ -191,7 +234,9 @@ extension ShowDetailView {
 }
 
 extension ShowWatchlistButton {
-  static func updateShowList(_ simkl_id: Int, _ accessToken: String, _ list: String) async -> String? {
+  static func updateShowList(_ simkl_id: Int, _ accessToken: String, _ list: String) async
+    -> String?
+  {
     do {
       if list == "nil" {
         let urlComponents = URLComponents(string: "https://api.simkl.com/sync/history/remove")!

--- a/simalytics/ViewModels/SimklMutationRequest.swift
+++ b/simalytics/ViewModels/SimklMutationRequest.swift
@@ -8,18 +8,64 @@
 import Foundation
 import Sentry
 
-enum SimklMutationError: Error {
+struct SimklServerErrorReason: Equatable, Sendable {
+  let code: String?
+  let message: String?
+}
+
+enum SimklMutationError: Error, Equatable, Sendable, CustomNSError {
   case invalidResponse
-  case httpStatusCode(Int)
+  case invalidEpisode
+  case httpStatusCode(Int, reason: SimklServerErrorReason?)
+
+  static var errorDomain: String { "Simalytics.SimklMutationError" }
+
+  var errorCode: Int {
+    switch self {
+    case .invalidResponse: 1
+    case .invalidEpisode: 2
+    case .httpStatusCode(let statusCode, _): statusCode
+    }
+  }
+
+  var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: diagnosticDescription]
+  }
+
+  private var diagnosticDescription: String {
+    switch self {
+    case .invalidResponse:
+      return "Simkl returned an invalid response."
+    case .invalidEpisode:
+      return "Episode mutation rejected before request: invalid season or episode."
+    case .httpStatusCode(let statusCode, let reason):
+      var details = ["HTTP \(statusCode)"]
+      if let code = reason?.code {
+        details.append("code \(code)")
+      }
+      if let message = reason?.message {
+        details.append(message)
+      }
+      return "Simkl rejected update (\(details.joined(separator: "; ")))."
+    }
+  }
 
   var isRetryable: Bool {
     switch self {
     case .invalidResponse:
       return true
-    case .httpStatusCode(let statusCode):
+    case .invalidEpisode:
+      return false
+    case .httpStatusCode(let statusCode, _):
       return statusCode == 429 || (500...599).contains(statusCode)
     }
   }
+}
+
+enum SimklMutationResult: Equatable, Sendable {
+  case succeeded
+  case cancelled
+  case failed(userMessage: String)
 }
 
 func simklAPIURL(path: String, queryItems: [URLQueryItem] = []) -> URL {
@@ -63,7 +109,9 @@ extension URLSession {
   }
 }
 
-func performSimklRequest(_ request: URLRequest, retryCount: Int = 2) async throws -> (Data, HTTPURLResponse) {
+func performSimklRequest(_ request: URLRequest, retryCount: Int = 2) async throws -> (
+  Data, HTTPURLResponse
+) {
   var attempt = 0
   var retryDelayNanoseconds: UInt64 = 500_000_000
 
@@ -75,7 +123,10 @@ func performSimklRequest(_ request: URLRequest, retryCount: Int = 2) async throw
       }
 
       guard (200...299).contains(httpResponse.statusCode) else {
-        throw SimklMutationError.httpStatusCode(httpResponse.statusCode)
+        throw SimklMutationError.httpStatusCode(
+          httpResponse.statusCode,
+          reason: parseSimklServerErrorReason(from: data)
+        )
       }
 
       return (data, httpResponse)
@@ -100,7 +151,9 @@ func simklMutationUserMessage(for error: Error) -> String {
     switch simklError {
     case .invalidResponse:
       return "Could not read Simkl's response. Please try again."
-    case .httpStatusCode(let statusCode):
+    case .invalidEpisode:
+      return "This episode has invalid season or episode information."
+    case .httpStatusCode(let statusCode, _):
       if statusCode == 401 {
         return "Your Simkl session has expired. Please sign in again."
       }
@@ -126,6 +179,107 @@ func simklMutationUserMessage(for error: Error) -> String {
   }
 
   return "Couldn't update your list. Please try again."
+}
+
+func parseSimklServerErrorReason(from data: Data) -> SimklServerErrorReason? {
+  guard data.count <= 64 * 1024,
+    let object = try? JSONSerialization.jsonObject(with: data),
+    let root = object as? [String: Any]
+  else { return nil }
+
+  let nestedError = root["error"] as? [String: Any]
+  let rawCode =
+    stringValue(root["code"])
+    ?? stringValue(root["error_code"])
+    ?? stringValue(nestedError?["code"])
+  let rawMessage =
+    stringValue(root["message"])
+    ?? stringValue(root["error_description"])
+    ?? (root["error"] as? String)
+    ?? stringValue(nestedError?["message"])
+
+  let reason = SimklServerErrorReason(
+    code: sanitizedSimklErrorCode(rawCode),
+    message: classifiedSimklErrorMessage(rawMessage)
+  )
+  return reason.code == nil && reason.message == nil ? nil : reason
+}
+
+private func stringValue(_ value: Any?) -> String? {
+  switch value {
+  case let string as String:
+    return string
+  case let number as NSNumber:
+    return number.stringValue
+  default:
+    return nil
+  }
+}
+
+private func sanitizedSimklErrorCode(_ rawCode: String?) -> String? {
+  guard let rawCode else { return nil }
+  let code = rawCode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  guard !code.isEmpty, code.count <= 48 else { return nil }
+
+  let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+  guard code.unicodeScalars.allSatisfy(allowed.contains) else { return nil }
+  if code.allSatisfy(\.isNumber) {
+    return code.count <= 4 ? code : nil
+  }
+
+  // Never retain an arbitrary server string, even when it looks code-like:
+  // a title or account identifier can also be short and alphanumeric.
+  // Normalize only known diagnostic categories to fixed values.
+  if code.contains("auth") || code.contains("token") || code.contains("unauthor") {
+    return "authentication_rejected"
+  }
+  if code.contains("rate") || code.contains("limit") {
+    return "rate_limited"
+  }
+  if code.contains("episode") || code.contains("season") {
+    return "invalid_episode"
+  }
+  if code.contains("not_found") || code.contains("not-found") || code.contains("notfound") {
+    return "not_found"
+  }
+  if code.contains("invalid") || code.contains("bad_request") || code.contains("validation") {
+    return "invalid_request"
+  }
+  if code.contains("duplicate") || code.contains("already") {
+    return "duplicate"
+  }
+  return nil
+}
+
+private func classifiedSimklErrorMessage(_ rawMessage: String?) -> String? {
+  guard let message = rawMessage?.lowercased() else { return nil }
+
+  if message.contains("unauthor") || message.contains("forbidden")
+    || message.contains("access token") || message.contains("authentication")
+  {
+    return "Authentication was rejected."
+  }
+  if message.contains("rate limit") || message.contains("too many request") {
+    return "Simkl rate-limited the request."
+  }
+  if (message.contains("episode") || message.contains("season"))
+    && (message.contains("invalid") || message.contains("missing")
+      || message.contains("required") || message.contains("unknown"))
+  {
+    return "Episode selection was rejected."
+  }
+  if message.contains("not found") || message.contains("not_found") {
+    return "The requested item was not found."
+  }
+  if message.contains("invalid request") || message.contains("bad request")
+    || message.contains("malformed") || message.contains("validation")
+  {
+    return "Simkl reported an invalid request."
+  }
+  if message.contains("duplicate") || message.contains("already") {
+    return "Simkl reported a duplicate update."
+  }
+  return nil
 }
 
 func isSimklCancellationError(_ error: Error) -> Bool {
@@ -178,7 +332,8 @@ private func shouldRetrySimklMutation(_ error: Error) -> Bool {
 
   if let urlError = error as? URLError {
     switch urlError.code {
-    case .timedOut, .networkConnectionLost, .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed, .notConnectedToInternet:
+    case .timedOut, .networkConnectionLost, .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+      .notConnectedToInternet:
       return true
     default:
       return false
@@ -192,12 +347,17 @@ private func appendSimklRequiredQueryItems(to components: inout URLComponents) {
   var queryItems = components.queryItems ?? []
   appendQueryItemIfMissing(URLQueryItem(name: "client_id", value: SIMKL_CLIENT_ID), to: &queryItems)
   appendQueryItemIfMissing(URLQueryItem(name: "app-name", value: SIMKL_APP_NAME), to: &queryItems)
-  appendQueryItemIfMissing(URLQueryItem(name: "app-version", value: SIMKL_APP_VERSION), to: &queryItems)
+  appendQueryItemIfMissing(
+    URLQueryItem(name: "app-version", value: SIMKL_APP_VERSION), to: &queryItems)
   components.queryItems = queryItems
 }
 
-private func appendQueryItemIfMissing(_ queryItem: URLQueryItem, to queryItems: inout [URLQueryItem]) {
-  guard !queryItems.contains(where: { $0.name.caseInsensitiveCompare(queryItem.name) == .orderedSame }) else {
+private func appendQueryItemIfMissing(
+  _ queryItem: URLQueryItem, to queryItems: inout [URLQueryItem]
+) {
+  guard
+    !queryItems.contains(where: { $0.name.caseInsensitiveCompare(queryItem.name) == .orderedSame })
+  else {
     return
   }
   queryItems.append(queryItem)

--- a/simalytics/ViewModels/SimklWatchedBatch.swift
+++ b/simalytics/ViewModels/SimklWatchedBatch.swift
@@ -15,6 +15,94 @@ import Foundation
 struct SimklWatchedBatch<T: Decodable & Sendable>: Sendable {
   let items: [T]
   let hadFailures: Bool
+  let terminalRejectionCount: Int
+}
+
+struct SimklWatchedDecodedResponse<T: Decodable & Sendable>: Sendable {
+  let items: [T]
+  let terminalRejectionCount: Int
+  let malformedItemCount: Int
+}
+
+private enum SimklWatchedElementDisposition<T> {
+  case item(T)
+  case terminalRejection
+  case malformed
+}
+
+private struct SimklWatchedResponseElement<T: Decodable>: Decodable {
+  private enum CodingKeys: String, CodingKey {
+    case result, simkl, ids
+  }
+
+  private enum IDKeys: String, CodingKey {
+    case simkl
+  }
+
+  let disposition: SimklWatchedElementDisposition<T>
+
+  init(from decoder: Decoder) throws {
+    do {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let topLevelID = try container.decodeIfPresent(Int.self, forKey: .simkl)
+      let nestedID = try? container.nestedContainer(keyedBy: IDKeys.self, forKey: .ids)
+        .decode(Int.self, forKey: .simkl)
+      let hasIdentifier = topLevelID != nil || nestedID != nil
+
+      if container.contains(.result) {
+        if let result = try? container.decode(Bool.self, forKey: .result) {
+          guard result else {
+            disposition = .malformed
+            return
+          }
+        } else if let result = try? container.decode(String.self, forKey: .result) {
+          if result == "not_found", hasIdentifier {
+            disposition = .terminalRejection
+          } else {
+            disposition = .malformed
+          }
+          return
+        } else {
+          disposition = .malformed
+          return
+        }
+      }
+
+      disposition = .item(try T(from: decoder))
+    } catch {
+      // The wrapper deliberately never throws for an individual element.
+      // That lets valid siblings survive while the aggregate decoder records
+      // a privacy-safe malformed count for telemetry and cache semantics.
+      disposition = .malformed
+    }
+  }
+}
+
+func decodeSimklWatchedResponse<T: Decodable & Sendable>(
+  _ type: T.Type,
+  from data: Data
+) throws -> SimklWatchedDecodedResponse<T> {
+  let elements = try JSONDecoder().decode([SimklWatchedResponseElement<T>].self, from: data)
+  var items: [T] = []
+  var terminalRejectionCount = 0
+  var malformedItemCount = 0
+
+  for element in elements {
+    switch element.disposition {
+    case .item(let item):
+      items.append(item)
+    case .terminalRejection:
+      terminalRejectionCount += 1
+    case .malformed:
+      malformedItemCount += 1
+    }
+  }
+
+  return SimklWatchedDecodedResponse(
+    items: items,
+    terminalRejectionCount: terminalRejectionCount,
+    malformedItemCount: malformedItemCount
+  )
 }
 
 // POSTs `simklIDs` to /sync/watched in 100-item chunks (Simkl's documented
@@ -27,7 +115,9 @@ func simklWatchedBatch<T: Decodable & Sendable>(
   type: String,
   accessToken: String
 ) async -> SimklWatchedBatch<T> {
-  guard !simklIDs.isEmpty else { return SimklWatchedBatch(items: [], hadFailures: false) }
+  guard !simklIDs.isEmpty else {
+    return SimklWatchedBatch(items: [], hadFailures: false, terminalRejectionCount: 0)
+  }
   let chunkSize = 100
   let chunks = stride(from: 0, to: simklIDs.count, by: chunkSize).map {
     Array(simklIDs[$0..<min($0 + chunkSize, simklIDs.count)])
@@ -35,6 +125,7 @@ func simklWatchedBatch<T: Decodable & Sendable>(
 
   var combined: [T] = []
   var hadFailures = false
+  var terminalRejectionCount = 0
   for chunk in chunks {
     do {
       let url = URL(string: "https://api.simkl.com/sync/watched?extended=episodes,specials")!
@@ -49,23 +140,69 @@ func simklWatchedBatch<T: Decodable & Sendable>(
       let (data, response) = try await URLSession.shared.simklData(for: request)
       if let status = (response as? HTTPURLResponse)?.statusCode, status != 200 {
         if shouldReportWatchedLookupStatus(status) {
-          reportError(NSError(
-            domain: "Simkl", code: status,
-            userInfo: [NSLocalizedDescriptionKey: "Batched /sync/watched (\(type)) returned HTTP \(status) for \(chunk.count) ids"]
-          ))
+          reportError(
+            NSError(
+              domain: "Simkl", code: status,
+              userInfo: [
+                NSLocalizedDescriptionKey:
+                  "Batched /sync/watched (\(type)) returned HTTP \(status) for \(chunk.count) ids"
+              ]
+            ))
         }
         hadFailures = true
         continue
       }
-      combined.append(contentsOf: try JSONDecoder().decode([T].self, from: data))
+      let decoded = try decodeSimklWatchedResponse(T.self, from: data)
+      combined.append(contentsOf: decoded.items)
+      terminalRejectionCount += decoded.terminalRejectionCount
+      if decoded.malformedItemCount > 0 {
+        reportSimklWatchedSchemaIssue(
+          type: type,
+          malformedItemCount: decoded.malformedItemCount,
+          responseItemCount: decoded.items.count + decoded.terminalRejectionCount
+            + decoded.malformedItemCount
+        )
+        hadFailures = true
+      }
     } catch {
-      reportError(error)
+      if error is DecodingError {
+        reportSimklWatchedSchemaIssue(type: type, malformedItemCount: nil, responseItemCount: nil)
+      } else {
+        reportError(error)
+      }
       hadFailures = true
     }
   }
-  return SimklWatchedBatch(items: combined, hadFailures: hadFailures)
+  return SimklWatchedBatch(
+    items: combined,
+    hadFailures: hadFailures,
+    terminalRejectionCount: terminalRejectionCount
+  )
 }
 
 private func shouldReportWatchedLookupStatus(_ status: Int) -> Bool {
   status != 429 && !(500...599).contains(status)
+}
+
+func reportSimklWatchedSchemaIssue(
+  type: String,
+  malformedItemCount: Int?,
+  responseItemCount: Int?
+) {
+  let detail: String
+  if let malformedItemCount, let responseItemCount {
+    detail =
+      "preserved valid siblings; malformed items: \(malformedItemCount) of \(responseItemCount)"
+  } else {
+    detail = "response was not a decodable item array"
+  }
+
+  reportError(
+    NSError(
+      domain: "SimklWatchedResponse",
+      code: 1,
+      userInfo: [
+        NSLocalizedDescriptionKey: "Batched /sync/watched (\(type)) schema mismatch; \(detail)"
+      ]
+    ))
 }

--- a/simalytics/ViewModels/Sync.swift
+++ b/simalytics/ViewModels/Sync.swift
@@ -67,15 +67,42 @@ func syncLatestActivities(
   guard await syncLatestActivitiesGate.begin(forceRefresh: forceRefresh) else { return }
 
   while true {
+    let syncStartedAt = Date()
+    addSyncLifecycleBreadcrumb(message: "Sync started", forceRefresh: runForceRefresh)
     await runSyncLatestActivities(
       accessToken,
       modelContainer: modelContainer,
       forceRefresh: runForceRefresh
     )
+    addSyncLifecycleBreadcrumb(
+      message: Task.isCancelled ? "Sync cancelled" : "Sync completed",
+      forceRefresh: runForceRefresh,
+      duration: Date().timeIntervalSince(syncStartedAt)
+    )
 
     guard let nextForceRefresh = await syncLatestActivitiesGate.finishCurrentRun() else { break }
     runForceRefresh = nextForceRefresh
   }
+
+  await MainActor.run {
+    NotificationCenter.default.post(name: .localMediaSnapshotsDidChange, object: nil)
+  }
+}
+
+private func addSyncLifecycleBreadcrumb(
+  message: String,
+  forceRefresh: Bool,
+  duration: TimeInterval? = nil
+) {
+  let breadcrumb = Breadcrumb(level: .info, category: "sync.lifecycle")
+  breadcrumb.type = "debug"
+  breadcrumb.message = message
+  var data: [String: Any] = ["force_refresh": forceRefresh]
+  if let duration {
+    data["duration_ms"] = Int((duration * 1_000).rounded())
+  }
+  breadcrumb.data = data
+  SentrySDK.addBreadcrumb(breadcrumb)
 }
 
 private func runSyncLatestActivities(
@@ -1809,10 +1836,12 @@ func processUpNextEpisodes(
       }
     }
 
-    // Only stamp the 6h cache as fresh if every batch chunk succeeded.
-    // If a /sync/watched chunk failed (rate limit, auth, network), the
-    // affected shows/anime kept their previous next_to_watch_info — we
-    // need the next scheduled run to retry instead of skipping for 6h.
+    // Only stamp the 6h cache as fresh if every batch chunk succeeded and
+    // every non-terminal item decoded. Simkl's per-item `not_found` result
+    // is terminal for that stale ID, so it is skipped without blocking the
+    // stamp; otherwise every app-triggered sync would immediately retry the
+    // same unrecoverable record. It remains part of the normal six-hour
+    // batch, while transport or schema failures still keep the cache stale.
     if !showWatchedBatch.hadFailures && !animeWatchedBatch.hadFailures {
       syncRecord!.changes_api = now.ISO8601Format()
       shouldSave = true

--- a/simalytics/Views/Explore/SearchResultsView.swift
+++ b/simalytics/Views/Explore/SearchResultsView.swift
@@ -17,9 +17,22 @@ struct SearchResultsView: View {
   @Environment(\.modelContext) private var context
   @State private var searchResults: [SearchResultModel] = []
   @State private var searchTask: Task<Void, Never>?
+  @State private var localSnapshots = LocalMediaSnapshots()
 
   private var visibleResults: [SearchResultModel] {
     searchResults.filter { !hideAnime || $0.endpoint_type != "anime" }
+  }
+
+  private var localSnapshotRequest: LocalMediaSnapshots.Request {
+    LocalMediaSnapshots.Request(
+      movieIDs: visibleResults.filter { $0.endpoint_type == "movies" }.map { $0.ids.simkl_id },
+      showIDs: visibleResults.filter { $0.endpoint_type == "tv" }.map { $0.ids.simkl_id },
+      animeIDs: visibleResults.filter { $0.endpoint_type == "anime" }.map { $0.ids.simkl_id }
+    )
+  }
+
+  private func refreshLocalSnapshots() {
+    localSnapshots = LocalMediaSnapshots.fetch(localSnapshotRequest, context: context)
   }
 
   @ViewBuilder
@@ -54,7 +67,7 @@ struct SearchResultsView: View {
       year: result.year,
       poster: result.poster,
       mediaType: mediaType,
-      localData: LocalDataLookup.lookup(simklId: result.ids.simkl_id, mediaType: mediaType, context: context)
+      localData: localSnapshots.data(simklID: result.ids.simkl_id, mediaType: mediaType)
     )
   }
 
@@ -114,6 +127,12 @@ struct SearchResultsView: View {
           .padding(.vertical, 8)
         }
       }
+    }
+    .task(id: localSnapshotRequest) {
+      refreshLocalSnapshots()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .localMediaSnapshotsDidChange)) { _ in
+      refreshLocalSnapshots()
     }
     .onChange(of: searchText) { _, newValue in
       SearchResultsView.debounceSearch(

--- a/simalytics/Views/Explore/TrendingListView.swift
+++ b/simalytics/Views/Explore/TrendingListView.swift
@@ -43,16 +43,41 @@ struct TrendingListView: View {
   @State private var movies: [V1.TrendingMovies] = []
   @State private var shows: [V1.TrendingShows] = []
   @State private var animes: [V1.TrendingAnimes] = []
+  @State private var localSnapshots = LocalMediaSnapshots()
+
+  private var localSnapshotRequest: LocalMediaSnapshots.Request {
+    switch category {
+    case .movies:
+      LocalMediaSnapshots.Request(movieIDs: movies.map(\.simkl))
+    case .tv:
+      LocalMediaSnapshots.Request(showIDs: shows.map(\.simkl))
+    case .anime:
+      LocalMediaSnapshots.Request(animeIDs: animes.map(\.simkl))
+    }
+  }
+
+  private func refreshLocalSnapshots() {
+    localSnapshots = LocalMediaSnapshots.fetch(localSnapshotRequest, context: context)
+  }
 
   private func fetchData() {
     do {
       switch category {
       case .movies:
-        movies = try context.fetch(FetchDescriptor<V1.TrendingMovies>(sortBy: [SortDescriptor(\V1.TrendingMovies.order, order: .forward)]))
+        movies = try context.fetch(
+          FetchDescriptor<V1.TrendingMovies>(sortBy: [
+            SortDescriptor(\V1.TrendingMovies.order, order: .forward)
+          ]))
       case .tv:
-        shows = try context.fetch(FetchDescriptor<V1.TrendingShows>(sortBy: [SortDescriptor(\V1.TrendingShows.order, order: .forward)]))
+        shows = try context.fetch(
+          FetchDescriptor<V1.TrendingShows>(sortBy: [
+            SortDescriptor(\V1.TrendingShows.order, order: .forward)
+          ]))
       case .anime:
-        animes = try context.fetch(FetchDescriptor<V1.TrendingAnimes>(sortBy: [SortDescriptor(\V1.TrendingAnimes.order, order: .forward)]))
+        animes = try context.fetch(
+          FetchDescriptor<V1.TrendingAnimes>(sortBy: [
+            SortDescriptor(\V1.TrendingAnimes.order, order: .forward)
+          ]))
       }
     } catch {
       // Leave empty on failure; grid will just show no items.
@@ -87,7 +112,7 @@ struct TrendingListView: View {
       year: year,
       poster: poster,
       mediaType: category.mediaType,
-      localData: LocalDataLookup.lookup(simklId: simkl, mediaType: category.mediaType, context: context)
+      localData: localSnapshots.data(simklID: simkl, mediaType: category.mediaType)
     )
   }
 
@@ -127,6 +152,13 @@ struct TrendingListView: View {
     }
     .navigationTitle(category.title)
     .navigationBarTitleDisplayMode(.inline)
-    .onAppear { fetchData() }
+    .task { fetchData() }
+    .task(id: localSnapshotRequest) {
+      refreshLocalSnapshots()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .localMediaSnapshotsDidChange)) { _ in
+      fetchData()
+      refreshLocalSnapshots()
+    }
   }
 }

--- a/simalytics/Views/ExploreView.swift
+++ b/simalytics/Views/ExploreView.swift
@@ -23,12 +23,34 @@ struct ExploreView: View {
   @State private var searchText: String = ""
   @State private var searchCategory: SearchCategory = .all
   @State private var isSearchPresented = false
+  @State private var localSnapshots = LocalMediaSnapshots()
+
+  private var localSnapshotRequest: LocalMediaSnapshots.Request {
+    LocalMediaSnapshots.Request(
+      movieIDs: sdTrendingMovies.map(\.simkl),
+      showIDs: sdTrendingShows.map(\.simkl),
+      animeIDs: hideAnime ? [] : sdTrendingAnimes.map(\.simkl)
+    )
+  }
+
+  private func refreshLocalSnapshots() {
+    localSnapshots = LocalMediaSnapshots.fetch(localSnapshotRequest, context: context)
+  }
 
   private func fetchData() {
     do {
-      sdTrendingMovies = try context.fetch(FetchDescriptor<V1.TrendingMovies>(sortBy: [SortDescriptor(\V1.TrendingMovies.order, order: .forward)]))
-      sdTrendingShows = try context.fetch(FetchDescriptor<V1.TrendingShows>(sortBy: [SortDescriptor(\V1.TrendingShows.order, order: .forward)]))
-      sdTrendingAnimes = try context.fetch(FetchDescriptor<V1.TrendingAnimes>(sortBy: [SortDescriptor(\V1.TrendingAnimes.order, order: .forward)]))
+      sdTrendingMovies = try context.fetch(
+        FetchDescriptor<V1.TrendingMovies>(sortBy: [
+          SortDescriptor(\V1.TrendingMovies.order, order: .forward)
+        ]))
+      sdTrendingShows = try context.fetch(
+        FetchDescriptor<V1.TrendingShows>(sortBy: [
+          SortDescriptor(\V1.TrendingShows.order, order: .forward)
+        ]))
+      sdTrendingAnimes = try context.fetch(
+        FetchDescriptor<V1.TrendingAnimes>(sortBy: [
+          SortDescriptor(\V1.TrendingAnimes.order, order: .forward)
+        ]))
     } catch {
       sdTrendingMovies = []
       sdTrendingShows = []
@@ -89,7 +111,7 @@ struct ExploreView: View {
                             year: nil,
                             poster: showItem.poster,
                             mediaType: "tv",
-                            localData: LocalDataLookup.lookup(simklId: showItem.simkl, mediaType: "tv", context: context)
+                            localData: localSnapshots.data(simklID: showItem.simkl, mediaType: "tv")
                           )
                         }
                       }
@@ -136,7 +158,8 @@ struct ExploreView: View {
                             year: nil,
                             poster: movieItem.poster,
                             mediaType: "movie",
-                            localData: LocalDataLookup.lookup(simklId: movieItem.simkl, mediaType: "movie", context: context)
+                            localData: localSnapshots.data(
+                              simklID: movieItem.simkl, mediaType: "movie")
                           )
                         }
                       }
@@ -184,7 +207,8 @@ struct ExploreView: View {
                               year: nil,
                               poster: animeItem.poster,
                               mediaType: "anime",
-                              localData: LocalDataLookup.lookup(simklId: animeItem.simkl, mediaType: "anime", context: context)
+                              localData: localSnapshots.data(
+                                simklID: animeItem.simkl, mediaType: "anime")
                             )
                           }
                         }
@@ -212,8 +236,15 @@ struct ExploreView: View {
           }
         }
       }
-      .onAppear {
+      .task {
         fetchData()
+      }
+      .task(id: localSnapshotRequest) {
+        refreshLocalSnapshots()
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .localMediaSnapshotsDidChange)) { _ in
+        fetchData()
+        refreshLocalSnapshots()
       }
       .searchable(text: $searchText, isPresented: $isSearchPresented, placement: .automatic)
       .searchScopes($searchCategory) {

--- a/simalytics/Views/Sheets/AnimeEpisodeView.swift
+++ b/simalytics/Views/Sheets/AnimeEpisodeView.swift
@@ -17,13 +17,17 @@ struct AnimeEpisodeView: View {
   @Binding var animeWatchlist: AnimeWatchlistModel?
   @Binding var animeDetails: AnimeDetailsModel?
   var simklId: Int
+  @State private var mutationCoordinator = EpisodeMutationCoordinator()
+  @State private var mutationTask: Task<Void, Never>?
 
   var body: some View {
-    let hasWatched = hasWatchedEpisode(season: episode?.type == "special" ? 0 : 1, episode: episode?.episode ?? -1)
+    let hasWatched = hasWatchedEpisode(
+      season: episode?.type == "special" ? 0 : 1, episode: episode?.episode ?? -1)
     VStack {
       HStack {
         CustomKFImage(
-          imageUrlString: episode?.img != nil ? "\(SIMKL_CDN_URL)/episodes/\(episode?.img! ?? "")_w.jpg" : nil,
+          imageUrlString: episode?.img != nil
+            ? "\(SIMKL_CDN_URL)/episodes/\(episode?.img! ?? "")_w.jpg" : nil,
           memoryCacheOnly: true,
           height: 70.42,
           width: 125
@@ -47,67 +51,29 @@ struct AnimeEpisodeView: View {
       }
 
       if episode?.episode != nil && episode?.season != nil && episode?.season != 0 {
-        Button(action: {
-          Task {
-            guard let ep = episode, let epNum = ep.episode else { return }
-            let seasonNum = ep.type == "special" ? 0 : 1
-            let willMarkWatched = !hasWatched
-
-            applyOptimisticAnimeWatchlistUpdate(
-              season: seasonNum, episode: epNum, watched: willMarkWatched)
-
-            if willMarkWatched {
-              optimisticallyClearNextToWatch(
-                simklId: simklId, season: seasonNum, episode: epNum,
-                kind: .anime, modelContainer: context.container)
-            }
-            invalidateUpNextCache(modelContainer: context.container)
-
-            let errorMessage: String?
-            if willMarkWatched {
-              errorMessage = await AnimeDetailView.markEpisodeWatched(
-                auth.simklAccessToken,
-                animeDetails?.title ?? "",
-                simklId,
-                seasonNum,
-                epNum
-              )
+        Button {
+          startMutation(hasWatched: hasWatched)
+        } label: {
+          Group {
+            if mutationCoordinator.isUpdating {
+              ProgressView()
+                .accessibilityLabel("Updating episode")
             } else {
-              errorMessage = await AnimeDetailView.markEpisodeUnwatched(
-                auth.simklAccessToken,
-                animeDetails?.title ?? "",
-                simklId,
-                seasonNum,
-                epNum
-              )
-            }
-
-            if errorMessage != nil {
-              applyOptimisticAnimeWatchlistUpdate(
-                season: seasonNum, episode: epNum, watched: !willMarkWatched)
-            }
-
-            await syncLatestActivities(
-              auth.simklAccessToken,
-              modelContainer: context.container,
-              forceRefresh: true
-            )
-
-            if let refreshed = await AnimeDetailView.getAnimeWatchlist(simklId, auth.simklAccessToken) {
-              animeWatchlist = refreshed
+              Text(hasWatched ? "Watched" : "Watch")
             }
           }
-        }) {
-          Text(hasWatched ? "Watched" : "Watch")
-            .frame(maxWidth: .infinity)
-            .padding()
-            .bold()
-            .background(hasWatched ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
-            .foregroundStyle(
-              hasWatched ? colorScheme == .dark ? Color.green : Color.green.darker() : colorScheme == .dark ? Color.gray : Color.gray.darker()
-            )
-            .clipShape(.rect(cornerRadius: 8))
+          .frame(maxWidth: .infinity)
+          .padding()
+          .bold()
+          .background(hasWatched ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
+          .foregroundStyle(
+            hasWatched
+              ? colorScheme == .dark ? Color.green : Color.green.darker()
+              : colorScheme == .dark ? Color.gray : Color.gray.darker()
+          )
+          .clipShape(.rect(cornerRadius: 8))
         }
+        .disabled(mutationCoordinator.isUpdating)
       }
 
       if let description = episode?.description {
@@ -118,7 +84,75 @@ struct AnimeEpisodeView: View {
       }
     }
     .padding([.leading, .trailing, .top])
+    .onDisappear {
+      mutationTask?.cancel()
+    }
     Spacer()
+  }
+
+  private func startMutation(hasWatched: Bool) {
+    guard mutationTask == nil, let ep = episode,
+      let selection = validatedSimklEpisode(
+        season: ep.type == "special" ? 0 : 1,
+        episode: ep.episode
+      )
+    else { return }
+
+    let originalWatchlist = animeWatchlist
+    let willMarkWatched = !hasWatched
+    let accessToken = auth.simklAccessToken
+    let title = animeDetails?.title ?? ""
+    let modelContainer = context.container
+
+    mutationTask = Task { @MainActor in
+      _ = await mutationCoordinator.run(
+        optimisticUpdate: {
+          applyOptimisticAnimeWatchlistUpdate(
+            season: selection.season,
+            episode: selection.episode,
+            watched: willMarkWatched
+          )
+          invalidateUpNextCache(modelContainer: modelContainer)
+        },
+        rollback: {
+          animeWatchlist = originalWatchlist
+        },
+        mutation: {
+          if willMarkWatched {
+            await AnimeDetailView.markEpisodeWatched(
+              accessToken, title, simklId, selection.season, selection.episode)
+          } else {
+            await AnimeDetailView.markEpisodeUnwatched(
+              accessToken, title, simklId, selection.season, selection.episode)
+          }
+        },
+        commit: {
+          if willMarkWatched {
+            optimisticallyClearNextToWatch(
+              simklId: simklId,
+              season: selection.season,
+              episode: selection.episode,
+              kind: .anime,
+              modelContainer: modelContainer
+            )
+          }
+        },
+        reconcile: {
+          await syncLatestActivities(
+            accessToken,
+            modelContainer: modelContainer,
+            forceRefresh: true
+          )
+          guard !Task.isCancelled else { return }
+          if let refreshed = await AnimeDetailView.getAnimeWatchlist(simklId, accessToken),
+            !Task.isCancelled
+          {
+            animeWatchlist = refreshed
+          }
+        }
+      )
+      mutationTask = nil
+    }
   }
 
   func hasWatchedEpisode(season targetSeason: Int, episode targetEpisode: Int) -> Bool {
@@ -134,7 +168,9 @@ struct AnimeEpisodeView: View {
     return false
   }
 
-  func applyOptimisticAnimeWatchlistUpdate(season targetSeason: Int, episode targetEpisode: Int, watched: Bool) {
+  func applyOptimisticAnimeWatchlistUpdate(
+    season targetSeason: Int, episode targetEpisode: Int, watched: Bool
+  ) {
     guard animeWatchlist != nil else { return }
     var working = animeWatchlist!
     var seasons = working.seasons ?? []
@@ -146,7 +182,8 @@ struct AnimeEpisodeView: View {
         episodes[epIdx].watched = watched
       } else {
         episodes.append(
-          WatchlistEpisode(number: targetEpisode, watched: watched, aired: true, last_watched_at: nil)
+          WatchlistEpisode(
+            number: targetEpisode, watched: watched, aired: true, last_watched_at: nil)
         )
       }
       season.episodes = episodes

--- a/simalytics/Views/Sheets/ShowEpisodeView.swift
+++ b/simalytics/Views/Sheets/ShowEpisodeView.swift
@@ -17,13 +17,17 @@ struct ShowEpisodeView: View {
   @Binding var showWatchlist: ShowWatchlistModel?
   @Binding var showDetails: ShowDetailsModel?
   var simklId: Int
+  @State private var mutationCoordinator = EpisodeMutationCoordinator()
+  @State private var mutationTask: Task<Void, Never>?
 
   var body: some View {
-    let hasWatched = hasWatchedEpisode(season: episode?.season ?? -1, episode: episode?.episode ?? -1)
+    let hasWatched = hasWatchedEpisode(
+      season: episode?.season ?? -1, episode: episode?.episode ?? -1)
     VStack {
       HStack {
         CustomKFImage(
-          imageUrlString: episode?.img != nil ? "\(SIMKL_CDN_URL)/episodes/\(episode?.img! ?? "")_w.jpg" : nil,
+          imageUrlString: episode?.img != nil
+            ? "\(SIMKL_CDN_URL)/episodes/\(episode?.img! ?? "")_w.jpg" : nil,
           memoryCacheOnly: true,
           height: 70.42,
           width: 125
@@ -47,75 +51,29 @@ struct ShowEpisodeView: View {
       }
 
       if episode?.episode != nil && episode?.season != nil {
-        Button(action: {
-          Task {
-            guard let ep = episode,
-              let epNum = ep.episode,
-              let seasonNum = ep.season
-            else { return }
-
-            let willMarkWatched = !hasWatched
-
-            // Optimistic local update to the in-memory watchlist so the
-            // button flips immediately without waiting on the round-trip.
-            applyOptimisticWatchlistUpdate(
-              season: seasonNum, episode: epNum, watched: willMarkWatched)
-
-            if willMarkWatched {
-              optimisticallyClearNextToWatch(
-                simklId: simklId, season: seasonNum, episode: epNum,
-                kind: .tv, modelContainer: context.container)
-            }
-            invalidateUpNextCache(modelContainer: context.container)
-
-            let errorMessage: String?
-            if willMarkWatched {
-              errorMessage = await ShowDetailView.markEpisodeWatched(
-                auth.simklAccessToken,
-                showDetails?.title ?? "",
-                simklId,
-                seasonNum,
-                epNum
-              )
+        Button {
+          startMutation(hasWatched: hasWatched)
+        } label: {
+          Group {
+            if mutationCoordinator.isUpdating {
+              ProgressView()
+                .accessibilityLabel("Updating episode")
             } else {
-              errorMessage = await ShowDetailView.markEpisodeUnwatched(
-                auth.simklAccessToken,
-                showDetails?.title ?? "",
-                simklId,
-                seasonNum,
-                epNum
-              )
-            }
-
-            if errorMessage != nil {
-              // Revert optimistic UI change and resync from server.
-              applyOptimisticWatchlistUpdate(
-                season: seasonNum, episode: epNum, watched: !willMarkWatched)
-            }
-
-            await syncLatestActivities(
-              auth.simklAccessToken,
-              modelContainer: context.container,
-              forceRefresh: true
-            )
-
-            // Pull fresh server-side watched state for this show so the
-            // sheet and detail view both reflect the new truth.
-            if let refreshed = await ShowDetailView.getShowWatchlist(simklId, auth.simklAccessToken) {
-              showWatchlist = refreshed
+              Text(hasWatched ? "Watched" : "Watch")
             }
           }
-        }) {
-          Text(hasWatched ? "Watched" : "Watch")
-            .frame(maxWidth: .infinity)
-            .padding()
-            .bold()
-            .background(hasWatched ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
-            .foregroundStyle(
-              hasWatched ? colorScheme == .dark ? Color.green : Color.green.darker() : colorScheme == .dark ? Color.gray : Color.gray.darker()
-            )
-            .clipShape(.rect(cornerRadius: 8))
+          .frame(maxWidth: .infinity)
+          .padding()
+          .bold()
+          .background(hasWatched ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
+          .foregroundStyle(
+            hasWatched
+              ? colorScheme == .dark ? Color.green : Color.green.darker()
+              : colorScheme == .dark ? Color.gray : Color.gray.darker()
+          )
+          .clipShape(.rect(cornerRadius: 8))
         }
+        .disabled(mutationCoordinator.isUpdating)
       }
 
       if let description = episode?.description {
@@ -126,7 +84,73 @@ struct ShowEpisodeView: View {
       }
     }
     .padding([.leading, .trailing, .top])
+    .onDisappear {
+      mutationTask?.cancel()
+    }
     Spacer()
+  }
+
+  private func startMutation(hasWatched: Bool) {
+    guard mutationTask == nil,
+      let ep = episode,
+      let selection = validatedSimklEpisode(season: ep.season, episode: ep.episode)
+    else { return }
+
+    let originalWatchlist = showWatchlist
+    let willMarkWatched = !hasWatched
+    let accessToken = auth.simklAccessToken
+    let title = showDetails?.title ?? ""
+    let modelContainer = context.container
+
+    mutationTask = Task { @MainActor in
+      _ = await mutationCoordinator.run(
+        optimisticUpdate: {
+          applyOptimisticWatchlistUpdate(
+            season: selection.season,
+            episode: selection.episode,
+            watched: willMarkWatched
+          )
+          invalidateUpNextCache(modelContainer: modelContainer)
+        },
+        rollback: {
+          showWatchlist = originalWatchlist
+        },
+        mutation: {
+          if willMarkWatched {
+            await ShowDetailView.markEpisodeWatched(
+              accessToken, title, simklId, selection.season, selection.episode)
+          } else {
+            await ShowDetailView.markEpisodeUnwatched(
+              accessToken, title, simklId, selection.season, selection.episode)
+          }
+        },
+        commit: {
+          if willMarkWatched {
+            optimisticallyClearNextToWatch(
+              simklId: simklId,
+              season: selection.season,
+              episode: selection.episode,
+              kind: .tv,
+              modelContainer: modelContainer
+            )
+          }
+        },
+        reconcile: {
+          await syncLatestActivities(
+            accessToken,
+            modelContainer: modelContainer,
+            forceRefresh: true
+          )
+          guard !Task.isCancelled else { return }
+          if let refreshed = await ShowDetailView.getShowWatchlist(simklId, accessToken),
+            !Task.isCancelled
+          {
+            showWatchlist = refreshed
+          }
+        }
+      )
+      mutationTask = nil
+    }
   }
 
   func hasWatchedEpisode(season targetSeason: Int, episode targetEpisode: Int) -> Bool {
@@ -145,7 +169,9 @@ struct ShowEpisodeView: View {
   // Updates showWatchlist in place. Synthesizes the season / episode entry
   // if it isn't already in the /sync/watched response (which happens on a
   // show with no prior watched episodes — the original code silently no-op'd).
-  func applyOptimisticWatchlistUpdate(season targetSeason: Int, episode targetEpisode: Int, watched: Bool) {
+  func applyOptimisticWatchlistUpdate(
+    season targetSeason: Int, episode targetEpisode: Int, watched: Bool
+  ) {
     guard showWatchlist != nil else { return }
     var working = showWatchlist!
     var seasons = working.seasons ?? []
@@ -157,7 +183,8 @@ struct ShowEpisodeView: View {
         episodes[epIdx].watched = watched
       } else {
         episodes.append(
-          WatchlistEpisode(number: targetEpisode, watched: watched, aired: true, last_watched_at: nil)
+          WatchlistEpisode(
+            number: targetEpisode, watched: watched, aired: true, last_watched_at: nil)
         )
       }
       season.episodes = episodes

--- a/simalyticsTests/EpisodeMutationCoordinatorTests.swift
+++ b/simalyticsTests/EpisodeMutationCoordinatorTests.swift
@@ -1,0 +1,116 @@
+import Testing
+
+@testable import Simalytics
+
+@MainActor
+@Suite("Episode mutation coordination")
+struct EpisodeMutationCoordinatorTests {
+  @Test("A second mutation is suppressed while the first owns the update")
+  func suppressesDoubleSubmission() async {
+    let coordinator = EpisodeMutationCoordinator()
+    let gate = TestGate()
+    let events = EventLog()
+
+    let first = Task { @MainActor in
+      await coordinator.run(
+        optimisticUpdate: { events.append("optimistic") },
+        rollback: { events.append("rollback") },
+        mutation: {
+          await gate.wait()
+          return .succeeded
+        },
+        commit: { events.append("commit") },
+        reconcile: { events.append("reconcile") }
+      )
+    }
+
+    while !gate.isWaiting {
+      await Task.yield()
+    }
+
+    let second = await coordinator.run(
+      optimisticUpdate: { events.append("unexpected optimistic") },
+      rollback: { events.append("unexpected rollback") },
+      mutation: { .succeeded },
+      commit: { events.append("unexpected commit") },
+      reconcile: { events.append("unexpected reconcile") }
+    )
+    #expect(second == .suppressed)
+
+    gate.open()
+    #expect(await first.value == .succeeded)
+    #expect(events.values == ["optimistic", "commit", "reconcile"])
+    #expect(!coordinator.isUpdating)
+  }
+
+  @Test("Failure rolls back once and reconciles once")
+  func rollsBackFailure() async {
+    let coordinator = EpisodeMutationCoordinator()
+    let events = EventLog()
+
+    let result = await coordinator.run(
+      optimisticUpdate: { events.append("optimistic") },
+      rollback: { events.append("rollback") },
+      mutation: { .failed(userMessage: "safe") },
+      commit: { events.append("commit") },
+      reconcile: { events.append("reconcile") }
+    )
+
+    #expect(result == .failed(userMessage: "safe"))
+    #expect(events.values == ["optimistic", "rollback", "reconcile"])
+  }
+
+  @Test("Cancellation restores the optimistic value without refresh work")
+  func rollsBackCancellation() async {
+    let coordinator = EpisodeMutationCoordinator()
+    let gate = TestGate()
+    let events = EventLog()
+    let task = Task { @MainActor in
+      await coordinator.run(
+        optimisticUpdate: { events.append("optimistic") },
+        rollback: { events.append("rollback") },
+        mutation: {
+          await gate.wait()
+          return Task.isCancelled ? .cancelled : .succeeded
+        },
+        commit: { events.append("commit") },
+        reconcile: { events.append("reconcile") }
+      )
+    }
+
+    while !gate.isWaiting {
+      await Task.yield()
+    }
+    task.cancel()
+    gate.open()
+
+    #expect(await task.value == .cancelled)
+    #expect(events.values == ["optimistic", "rollback"])
+    #expect(!coordinator.isUpdating)
+  }
+}
+
+@MainActor
+private final class TestGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private(set) var isWaiting = false
+
+  func wait() async {
+    isWaiting = true
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func open() {
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+@MainActor
+private final class EventLog {
+  private(set) var values: [String] = []
+
+  func append(_ value: String) {
+    values.append(value)
+  }
+}

--- a/simalyticsTests/LocalMediaSnapshotsTests.swift
+++ b/simalyticsTests/LocalMediaSnapshotsTests.swift
@@ -1,0 +1,84 @@
+import SwiftData
+import Testing
+
+@testable import Simalytics
+
+@MainActor
+@Suite("Local media snapshots")
+struct LocalMediaSnapshotsTests {
+  @Test("Bulk snapshot covers all media types and only requested IDs")
+  func fetchesAllMediaTypes() throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+    context.insert(V1.SDMovies(simkl: 1, status: "completed", user_rating: 8, year: 2024))
+    context.insert(
+      V1.SDShows(
+        simkl: 2,
+        user_rating: 7,
+        status: "watching",
+        watched_episodes_count: 3,
+        total_episodes_count: 10,
+        year: 2025
+      ))
+    context.insert(
+      V1.SDAnimes(
+        simkl: 3,
+        user_rating: 9,
+        status: "watching",
+        watched_episodes_count: 12,
+        total_episodes_count: 24,
+        anime_type: "tv",
+        year: 2023
+      ))
+    context.insert(V1.SDMovies(simkl: 99, status: "plantowatch"))
+    try context.save()
+
+    let snapshots = LocalMediaSnapshots.fetch(
+      .init(movieIDs: [1, 1], showIDs: [2], animeIDs: [3]),
+      context: context
+    )
+
+    #expect(
+      snapshots.data(simklID: 1, mediaType: "movie")
+        == LocalMediaData(
+          year: 2024,
+          userRating: 8,
+          status: "completed",
+          animeType: nil,
+          watchedEpisodes: nil,
+          totalEpisodes: nil
+        ))
+    #expect(snapshots.data(simklID: 2, mediaType: "tv")?.watchedEpisodes == 3)
+    #expect(snapshots.data(simklID: 3, mediaType: "anime")?.animeType == "tv")
+    #expect(snapshots.data(simklID: 99, mediaType: "movie") == nil)
+  }
+
+  @Test("A new snapshot observes saved rating and watchlist changes")
+  func refreshesAfterSavedChange() throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+    let show = V1.SDShows(simkl: 12, user_rating: 4, status: "plantowatch")
+    context.insert(show)
+    try context.save()
+
+    let request = LocalMediaSnapshots.Request(showIDs: [12])
+    let original = LocalMediaSnapshots.fetch(request, context: context)
+    #expect(original.data(simklID: 12, mediaType: "tv")?.userRating == 4)
+
+    show.user_rating = 10
+    show.status = "completed"
+    try context.save()
+
+    let refreshed = LocalMediaSnapshots.fetch(request, context: context)
+    #expect(refreshed.data(simklID: 12, mediaType: "tv")?.userRating == 10)
+    #expect(refreshed.data(simklID: 12, mediaType: "tv")?.status == "completed")
+  }
+
+  private func makeContainer() throws -> ModelContainer {
+    let schema = Schema(V1.models)
+    return try ModelContainer(
+      for: schema,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+  }
+}

--- a/simalyticsTests/MarkWatchedHelpersTests.swift
+++ b/simalyticsTests/MarkWatchedHelpersTests.swift
@@ -6,10 +6,11 @@
 //  invalidation used by the mark-watched flow.
 //
 
+import Foundation
 import SwiftData
 import Testing
 
-@testable import simalytics
+@testable import Simalytics
 
 @MainActor
 @Suite("MarkWatchedHelpers")

--- a/simalyticsTests/ProcessUpNextEpisodesTests.swift
+++ b/simalyticsTests/ProcessUpNextEpisodesTests.swift
@@ -10,10 +10,11 @@
 //  during the May 2026 review).
 //
 
+import Foundation
 import SwiftData
 import Testing
 
-@testable import simalytics
+@testable import Simalytics
 
 @MainActor
 @Suite("processUpNextEpisodes — cache + sequencing")
@@ -45,7 +46,8 @@ struct ProcessUpNextCacheTests {
     let refreshed = try ModelContext(container).fetch(
       FetchDescriptor<V1.SDLastSync>(predicate: #Predicate { $0.id == 1 })
     ).first
-    #expect(refreshed?.changes_api == nil, "changes_api must be the field invalidateUpNextCache nulls")
+    #expect(
+      refreshed?.changes_api == nil, "changes_api must be the field invalidateUpNextCache nulls")
   }
 
   @Test("Up Next mark-watched refuses missing or invalid episode numbers")

--- a/simalyticsTests/SimklMutationRequestTests.swift
+++ b/simalyticsTests/SimklMutationRequestTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import Simalytics
+
+@Suite("Simkl mutation errors")
+struct SimklMutationRequestTests {
+  @Test("Cancellation variants remain recognized")
+  func recognizesCancellation() {
+    #expect(isSimklCancellationError(CancellationError()))
+    #expect(isSimklCancellationError(URLError(.cancelled)))
+    #expect(
+      isSimklCancellationError(
+        NSError(domain: NSURLErrorDomain, code: URLError.cancelled.rawValue)
+      ))
+    #expect(!isSimklCancellationError(URLError(.timedOut)))
+  }
+
+  @Test(
+    "Expected transient network failures remain filtered",
+    arguments: [
+      URLError.Code.timedOut,
+      .networkConnectionLost,
+      .notConnectedToInternet,
+      .cannotConnectToHost,
+      .cannotFindHost,
+      .dnsLookupFailed,
+    ]
+  )
+  func recognizesExpectedTransientURLFailures(code: URLError.Code) {
+    #expect(isExpectedTransientNetworkError(URLError(code)))
+    #expect(
+      isExpectedTransientNetworkError(
+        NSError(domain: NSURLErrorDomain, code: code.rawValue)
+      ))
+  }
+
+  @Test("Deterministic schema and authentication failures are not filtered")
+  func doesNotFilterDeterministicFailures() {
+    let decoding = DecodingError.dataCorrupted(
+      .init(codingPath: [], debugDescription: "contract mismatch")
+    )
+    #expect(!isExpectedTransientNetworkError(decoding))
+    #expect(!isSimklCancellationError(decoding))
+
+    let authentication = SimklMutationError.httpStatusCode(401, reason: nil)
+    #expect(!isExpectedTransientNetworkError(authentication))
+    #expect(!isSimklCancellationError(authentication))
+  }
+
+  @Test("Server reason retains only bounded safe categories")
+  func sanitizesServerReason() throws {
+    let data = try #require(
+      """
+      {"code":"invalid_episode","message":"Episode 4 is invalid; token secret-value and private title"}
+      """.data(using: .utf8)
+    )
+    let reason = try #require(parseSimklServerErrorReason(from: data))
+
+    #expect(reason.code == "invalid_episode")
+    #expect(reason.message == "Episode selection was rejected.")
+    #expect(!String(describing: reason).contains("secret-value"))
+    #expect(!String(describing: reason).contains("private title"))
+  }
+
+  @Test("Unsafe server fields are discarded")
+  func discardsUnsafeReason() throws {
+    let oversizedNumericCode = String(repeating: "7", count: 20)
+    let data = try JSONSerialization.data(
+      withJSONObject: [
+        "code": "PrivateTitle",
+        "secondary_code": oversizedNumericCode,
+        "message": "Unclassified private response details",
+      ])
+
+    #expect(parseSimklServerErrorReason(from: data) == nil)
+  }
+}

--- a/simalyticsTests/SimklWatchedBatchTests.swift
+++ b/simalyticsTests/SimklWatchedBatchTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import Simalytics
+
+@Suite(
+  "Simkl watched response decoding",
+  .bug("https://kyter.sentry.io/issues/7599289548/", "Malformed watched response")
+)
+struct SimklWatchedBatchTests {
+  @Test("Show item uses its top-level Simkl ID")
+  func showUsesTopLevelID() throws {
+    let response = try decode(
+      ShowWatchlistModel.self,
+      json: """
+        [{"simkl":42,"ids":{"simkl":99},"result":true,"list":"watching","episodes_watched":3,"seasons":[]}]
+        """
+    )
+
+    let item = try #require(response.items.first)
+    #expect(item.simkl == 42)
+    #expect(item.list == "watching")
+    #expect(item.episodes_watched == 3)
+    #expect(response.malformedItemCount == 0)
+  }
+
+  @Test("Show item falls back to nested Simkl ID")
+  func showUsesNestedID() throws {
+    let response = try decode(
+      ShowWatchlistModel.self,
+      json: """
+        [{"ids":{"simkl":77},"result":true,"type":"show","list":"completed","seasons":[]}]
+        """
+    )
+
+    #expect(response.items.map(\.simkl) == [77])
+    #expect(response.items.first?.list == "completed")
+    #expect(response.terminalRejectionCount == 0)
+  }
+
+  @Test("Terminal not-found item is represented but not decoded as watched data")
+  func notFoundIsTerminalRejection() throws {
+    let response = try decode(
+      ShowWatchlistModel.self,
+      json: """
+        [{"ids":{"simkl":77},"result":"not_found","type":"show"}]
+        """
+    )
+
+    #expect(response.items.isEmpty)
+    #expect(response.terminalRejectionCount == 1)
+    #expect(response.malformedItemCount == 0)
+  }
+
+  @Test("Malformed sibling cannot discard valid data")
+  func mixedArrayPreservesValidSibling() throws {
+    let response = try decode(
+      ShowWatchlistModel.self,
+      json: """
+        [
+          {"simkl":11,"result":true,"list":"watching","seasons":[]},
+          {"result":true,"type":"show","list":"watching"},
+          {"ids":{"simkl":12},"result":"not_found","type":"show"}
+        ]
+        """
+    )
+
+    #expect(response.items.map(\.simkl) == [11])
+    #expect(response.malformedItemCount == 1)
+    #expect(response.terminalRejectionCount == 1)
+  }
+
+  @Test("Normal anime response still decodes")
+  func animeResponseDecodesNormally() throws {
+    let response = try decode(
+      AnimeWatchlistModel.self,
+      json: """
+        [{"simkl":101,"result":true,"list":"watching","episodes_watched":8,"episodes_aired":12,"seasons":[]}]
+        """
+    )
+
+    let item = try #require(response.items.first)
+    #expect(item.simkl == 101)
+    #expect(item.episodes_watched == 8)
+    #expect(item.episodes_aired == 12)
+    #expect(item.seasons?.isEmpty == true)
+  }
+
+  private func decode<T: Decodable & Sendable>(
+    _ type: T.Type,
+    json: String
+  ) throws -> SimklWatchedDecodedResponse<T> {
+    try decodeSimklWatchedResponse(type, from: Data(json.utf8))
+  }
+}

--- a/simalyticsTests/WatchlistOptimisticUpdateTests.swift
+++ b/simalyticsTests/WatchlistOptimisticUpdateTests.swift
@@ -12,7 +12,7 @@
 
 import Testing
 
-@testable import simalytics
+@testable import Simalytics
 
 @Suite("Watchlist optimistic update")
 struct WatchlistOptimisticUpdateTests {
@@ -31,7 +31,8 @@ struct WatchlistOptimisticUpdateTests {
         eps[epIdx].watched = watched
       } else {
         eps.append(
-          WatchlistEpisode(number: targetEpisode, watched: watched, aired: true, last_watched_at: nil)
+          WatchlistEpisode(
+            number: targetEpisode, watched: watched, aired: true, last_watched_at: nil)
         )
       }
       s.episodes = eps


### PR DESCRIPTION
## What changed

- Decode `/sync/watched` items independently, accepting `ids.simkl` when the top-level ID is absent and treating `result: "not_found"` as a terminal skipped item instead of rejecting the whole batch.
- Remove Kingfisher's per-poster fade from the shared collection image component while preserving downsampling, cancellation, cache ownership, placeholders, and disk limits.
- Replace per-preview SwiftData fetches with value-only bulk snapshots (at most one query per requested media type), refreshed after sync/mutation invalidation.
- Serialize episode-sheet mutations behind an observable in-flight coordinator, with exact optimistic rollback, deliberate cancellation, final boundary validation, and bounded privacy-safe server diagnostics.
- Add low-volume sync start/completion timing breadcrumbs for future watchdog correlation without account data.
- Restore the unit-test target, add focused Swift Testing regressions, and add a patch Changeset.

## Why

Live Sentry data and a read-only Simkl reproduction confirmed that one stale watched item could omit top-level `simkl` while retaining `ids.simkl`, causing all valid siblings to be discarded. Separate Sentry stacks showed dense Kingfisher fade completions publishing simultaneous SwiftUI animations, 33–37 synchronous per-item SwiftData preview fetches, and episode-sheet requests that could be submitted twice.

The watchdog group remains ambiguous: it has no actionable stack or resource context. This PR reduces two supported pressure sources and adds targeted sync timing evidence, but intentionally does not claim the watchdog is fixed.

## Validation

- Full Swift Testing suite: 36/36 passed on iPhone 17 Pro, iOS 26.5.
- Focused decoder, bulk-fetch, mutation-coordinator, cancellation/network-filter, and sanitization suites passed.
- Debug iPad Pro 13-inch (M5), iOS 26.5 build succeeded.
- Release generic iOS Simulator build succeeded.
- Offline dense-grid fixture stress: 6/6 launches remained alive on both iPhone and iPad; both layouts were visually checked.
- Authorized live Simkl episode add/remove returned HTTP 201, the watched state changed as expected, and the complete normalized watched item matched its pre-test baseline after removal.
- `swift-format lint --strict` passed for new core/test files.
- `npm run release:check`, `npx changeset status`, and `git diff --check` passed.

No Sentry issue state, release, version, or build number was changed.
